### PR TITLE
Chore: Update pinned SHA commits for upstream actions

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -8,6 +8,7 @@
 
 name: 🔐 Scorecard Auditing
 on:
+  workflow_dispatch:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
   branch_protection_rule:
@@ -17,6 +18,9 @@ on:
     - cron: "31 3 * * 0"
   push:
     branches: ["main"]
+    paths:
+      - "**"
+      - "!.github/**"
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -41,14 +45,14 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Also, do NOT run scorecard when updating GHA .github files, etc.