### PR TITLE
Chore: Pass in python version to dependencies action

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -52,9 +52,8 @@ jobs:
 
       - name: "Update Python dependencies"
         uses: pdm-project/update-deps-action@v1.9
-        env:
-          python-version: ${{ env.default-python }}
         with:
+          python-version: ${{ env.default-python }}
           sign-off-commit: "true"
           token: ${{ github.token }}
           commit-message: "Chore: Update dependencies and pdm.lock [skip ci]"


### PR DESCRIPTION
Fixes the warning with pdm-project/setup-pdm@v4:
Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find 'pyproject.toml' file.
