### PR TITLE
Fix: project-name-vs-repo-action incorrect results

### DIFF
--- a/.github/actions/project-name-vs-repo-action/action.yaml
+++ b/.github/actions/project-name-vs-repo-action/action.yaml
@@ -41,7 +41,7 @@ runs:
 
         echo "GITHUB_REPOSITORY_NAME: $GITHUB_REPOSITORY_NAME"
 
-        PYTHON_PROJECT_NAME="${{ steps.project-name-vs-repo-action.outputs.python_project_name }}"
+        PYTHON_PROJECT_NAME="${{ steps.python-get-project-name-action.outputs.python_project_name }}"
         echo "PYTHON_PROJECT_NAME: $PYTHON_PROJECT_NAME"
 
         if [[ "$GITHUB_REPOSITORY_NAME" == "$PYTHON_PROJECT_NAME" ]]; then


### PR DESCRIPTION
The file project-name-vs-repo-action/action.yaml had a mismatch, where the called action name and step output were misaligned, which meant the data comparison was always invalid. This was introduced when the actions were bulk renamed in previous commits today.