### PR TITLE
Chore: Enable attestations for further testing

### DIFF
--- a/.github/actions/github-list-releases-action/action.yaml
+++ b/.github/actions/github-list-releases-action/action.yaml
@@ -106,7 +106,7 @@ runs:
         fi
 
         # Run and capture GitHub CLI Command
-        if [ "$RETURN_TYPE" = "test" ]; then
+        if [ "$RETURN_TYPE" = "text" ]; then
           # Text output is actually a JSON query processed with fixed arguments
           echo "Running: $GH_CLI $CLI_FLAGS"
           RELEASES=$($GH_CLI $CLI_FLAGS --json tagName -q '.[] | .tagName')
@@ -127,13 +127,14 @@ runs:
         fi
 
         # Check with leading character in place
+        echo "Checking release list for: $TAG"
         checkReleases
 
         if [ "$RELEASED" != "true" ]; then
           if [[ "$TAG" == v* ]]; then
             TAG="${TAG:1}"
             # Check again with leading 'v' character stripped
-            echo "Checking tag input with leading character stripped"
+            echo "Checking release list for: $TAG"
             checkReleases
           fi
         fi
@@ -145,7 +146,7 @@ runs:
         if [ "$RELEASED" = "true" ]; then
           echo "$TAG HAS already been release ⚠️"
         else
-          echo "$TAG has not prviously been released ✅"
+          echo "$TAG has not previously been released ✅"
         fi
         if [ "f$SUMMARY_OUTPUT" = "ftrue" ]; then
           if [ "$RELEASED" = "true" ]; then

--- a/.github/actions/pypi-publish-action/action.yaml
+++ b/.github/actions/pypi-publish-action/action.yaml
@@ -37,6 +37,11 @@ inputs:
     type: string
     required: false
     default: "false"
+  ATTESTATIONS:
+    description: "Enables upload/publishing support for attestations"
+    type: string
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -105,9 +110,9 @@ runs:
       # yamllint disable-line rule:line-length
       uses: os-climate/osc-github-devops/.github/actions/pypi-version-check-action@main
       with:
-        index_url: "${{ env.base_url }}/simple"
-        package_name: "${{ steps.naming.outputs.python_project_name }}"
-        package_version: "${{ inputs.tag }}"
+        index_url: ${{ env.base_url }}/simple
+        package_name: ${{ steps.naming.outputs.python_project_name }}
+        package_version: ${{ inputs.tag }}
         environment: ${{ env.ENVIRONMENT }}
 
     - name: "Determine publishing method"
@@ -174,19 +179,19 @@ runs:
       # Currently it causes failures, and will need careful testing
       # Also, be cautious pinning v1.12.x to a SHA commit value:
       # https://github.com/pypa/gh-action-pypi-publish/discussions/287
-      uses: pypa/gh-action-pypi-publish@fb13cb306901256ace3dab689990e13a5550ffaa # v1.11.0
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       # yamllint disable-line rule:line-length
       if: env.publish_method == 'Trusted Publishing' && inputs.publish_disable == 'false'
       with:
-        repository-url: "${{ env.publish_url }}"
+        repository-url: ${{ env.publish_url }}
+        packages-dir: ${{ inputs.artefact_path }}
+        # We already validated earlier in the pipeline (twine)
+        verify-metadata: false
+        attestations: ${{ inputs.attestations }}
         # Show checksum values
         print-hash: true
-        packages-dir: ${{ inputs.artefact_path }}
-        # We already validated earlier in the pipeline (using twine)
-        verify-metadata: false
         # Optional debugging, pretty much essential for information on failures
         verbose: true
-        attestations: true # Currently too buggy to enable?
 
     - name: "Retrieve Credential [1Password]"
       id: one-password-pypi-test
@@ -196,7 +201,7 @@ runs:
         # Export loaded secrets as environment variables
         export-env: true
       env:
-        PYPI_CREDENTIAL: "${{ inputs.ONE_PASSWORD_ITEM}}"
+        PYPI_CREDENTIAL: ${{ inputs.ONE_PASSWORD_ITEM}}
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}
 
     # Used only once prior to trusted publishing being configured
@@ -205,18 +210,18 @@ runs:
       # Currently it causes failures, and will need careful testing
       # Also, be cautious pinning v1.12.x to a SHA commit value:
       # https://github.com/pypa/gh-action-pypi-publish/discussions/287
-      uses: pypa/gh-action-pypi-publish@fb13cb306901256ace3dab689990e13a5550ffaa # v1.11.0
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       # yamllint disable-line rule:line-length
       if: env.publish_method == '1Password Vault' && inputs.publish_disable == 'false'
       with:
-        repository-url: "${{ env.publish_url }}"
-        print-hash: true
+        repository-url: ${{ env.publish_url }}
         packages-dir: ${{ inputs.artefact_path }}
         verify-metadata: false
-        verbose: true
         # Credential retrieved from 1Password using service account
-        password: "${{ env.PYPI_CREDENTIAL}}"
-        attestations: false
+        password: ${{ env.PYPI_CREDENTIAL}}
+        attestations: ${{ inputs.attestations }}
+        print-hash: true
+        verbose: true
 
     # Fallback method using credential stored as GitHub secret
     - name: "Publish PyPI [GitHub Secret]"
@@ -224,19 +229,19 @@ runs:
       # Currently it causes failures, and will need careful testing
       # Also, be cautious pinning v1.12.x to a SHA commit value:
       # https://github.com/pypa/gh-action-pypi-publish/discussions/287
-      uses: pypa/gh-action-pypi-publish@fb13cb306901256ace3dab689990e13a5550ffaa # v1.11.0
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       if:
         # yamllint disable-line rule:line-length
         env.publish_method == 'GitHub Secret' && inputs.publish_disable == 'false'
       with:
-        repository-url: "${{ env.publish_url }}"
-        print-hash: true
+        repository-url: ${{ env.publish_url }}
         packages-dir: ${{ inputs.artefact_path }}
         verify-metadata: false
-        verbose: true
         # Publishing API key stored as secret/variable in GitHub
         password: ${{ inputs.PYPI_CREDENTIAL }}
-        attestations: false
+        attestations: ${{ inputs.attestations }}
+        print-hash: true
+        verbose: true
 
     - name: "Print summary/job output"
       shell: bash

--- a/.github/actions/python-project-build-action/action.yaml
+++ b/.github/actions/python-project-build-action/action.yaml
@@ -18,7 +18,7 @@ inputs:
   TAG:
     description: "Tag version/name for this specific build (semantic)"
     required: false
-  GITHUB_ATTEST:
+  ATTESTATIONS:
     # Attestations should not be used for development builds
     description: "Apply GitHub attestations to artefacts"
     required: false
@@ -173,7 +173,7 @@ runs:
 
     - name: "Artefact attestation for: ${{ inputs.ARTEFACT_PATH }}"
       uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0
-      if: ${{ inputs.github_attest == 'true' }}
+      if: ${{ inputs.attestations == 'true' }}
       with:
         subject-path: ${{ inputs.ARTEFACT_PATH }}/*
 

--- a/.github/workflows/merge-build-test-release.yaml
+++ b/.github/workflows/merge-build-test-release.yaml
@@ -86,6 +86,8 @@ jobs:
         uses: os-climate/osc-github-devops/.github/actions/python-project-build-action@main
         with:
           tag: ${{ needs.repository.outputs.build_tag }}
+          attestations: "true"
+          sigstore_sign: "true"
 
   python-test:
     name: "Test"
@@ -167,6 +169,7 @@ jobs:
           op_service_account_token: ${{ secrets.ONE_PASSWORD_PRODUCTION }}
           pypi_credential: ${{ secrets.PYPI_PRODUCTION }}
           publish_disable: ${{ env.pypi_publish_disable }}
+          attestations: "true"
 
   pypi-release:
     name: "PyPI release"
@@ -199,6 +202,7 @@ jobs:
           op_service_account_token: ${{ secrets.ONE_PASSWORD_PRODUCTION }}
           pypi_credential: ${{ secrets.PYPI_PRODUCTION }}
           publish_disable: ${{ env.pypi_publish_disable }}
+          attestations: "true"
 
   github-release:
     name: "GitHub release"

--- a/.github/workflows/merge-test-gha.yaml
+++ b/.github/workflows/merge-test-gha.yaml
@@ -135,7 +135,7 @@ jobs:
         run: |
           # Check output from: python-project-version-action
           PYTHON_PROJECT_VERSION="${{ steps.python-project.outputs.python_project_version }}"
-          if [ "$PYTHON_PROJECT_VERSION" != "0.1.24" ]; then
+          if [ "$PYTHON_PROJECT_VERSION" != "0.1.25" ]; then
             echo "ERROR: Python project version was not as expected"
             echo "python_project_version: $PYTHON_PROJECT_VERSION"; exit 1
           else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "osc-github-devops"
-version = "0.1.24"
+version = "0.1.25"
 # Uncomment to enable dynamic versioning
 # dynamic = [ "version" ]
 description = "Python project template"


### PR DESCRIPTION
Update to upstream gh-action-pypi-publish v1.12.4
Enable GitHub attestations for tag push builds/releases
Enable Sigstore signing for tag push builds/releases