### PR TITLE
Fix: Pass PYPI_CREDENTIAL secrets explicitly

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -134,32 +134,6 @@ jobs:
         with:
           python_version: "${{ matrix.python-version }}"
 
-  notebooks:
-    name: 'Test Jupyter Notebooks'
-    runs-on: 'ubuntu-latest'
-    needs: 'python-build'
-    # Matrix job
-    strategy:
-      fail-fast: false
-      matrix: "${{ fromJson(needs.python-build.outputs.matrix_json) }}"
-    permissions:
-      contents: read
-    timeout-minutes: 10
-    steps:
-      # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: 'audit'
-
-      # yamllint disable-line rule:line-length
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      # yamllint disable-line rule:line-length
-      - uses: lfreleng-actions/python-notebook-test-action@3387386550d89ce9e9e5864aa793c67f9774b71f # v0.1.2
-        with:
-          python_version: "${{ matrix.python-version }}"
-
   test-pypi:
     name: 'Test PyPI Publishing'
     runs-on: 'ubuntu-latest'
@@ -167,7 +141,6 @@ jobs:
       - 'tag-validate'
       - 'python-tests'
       - 'python-audit'
-      - 'notebooks'
     environment:
       name: 'development'
     permissions:
@@ -190,6 +163,7 @@ jobs:
         with:
           environment: 'development'
           tag: "${{ needs.tag-validate.outputs.tag }}"
+          pypi_credential: "${{ secrets.PYPI_CREDENTIAL }}"
 
   pypi:
     name: 'Release PyPI Package'
@@ -220,6 +194,7 @@ jobs:
           environment: 'production'
           attestations: true
           tag: "${{ needs.tag-validate.outputs.tag }}"
+          pypi_credential: "${{ secrets.PYPI_CREDENTIAL }}"
 
   promote-release:
     name: 'Promote Draft Release'

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -106,30 +106,3 @@ jobs:
         uses: lfreleng-actions/python-audit-action@bab5316468c108870eb759ef0de622bae9239aad # v0.2.2
         with:
           python_version: "${{ matrix.python-version }}"
-
-  notebooks:
-    name: 'Test Jupyter Notebooks'
-    runs-on: 'ubuntu-latest'
-    needs: 'python-build'
-    # Matrix job
-    strategy:
-      fail-fast: false
-      matrix: "${{ fromJson(needs.python-build.outputs.matrix_json) }}"
-    permissions:
-      contents: read
-    timeout-minutes: 10
-    steps:
-      # Harden the runner used by this workflow
-      # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: 'audit'
-
-      # yamllint disable-line rule:line-length
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: "Notebook tests ${{ matrix.python-version }}"
-        # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/python-notebook-test-action@3387386550d89ce9e9e5864aa793c67f9774b71f # v0.1.2
-        with:
-          python_version: "${{ matrix.python-version }}"


### PR DESCRIPTION
Removed Notebook testing from build-test.yaml and build-test-release.yaml.